### PR TITLE
Add Doxygen documentation support and update CMake configuration

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -76,3 +76,43 @@ jobs:
           fi
         done
 
+  # Build and deploy Doxygen to GitHub Pages
+  deploy-docs:
+    name: Build & Deploy Doxygen
+    if: github.ref == 'refs/heads/main'
+    needs: check-docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y doxygen graphviz
+
+    - name: Configure (enable docs)
+      run: cmake -S . -B build -DTHREADSCHEDULE_BUILD_DOCS=ON
+
+    - name: Build docs
+      run: cmake --build build --target docs -- -j
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: build/docs/doxygen/html
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,11 @@ endif()
 
 # Options
 option(THREADSCHEDULE_BUILD_EXAMPLES "Build examples" ${THREADSCHEDULE_IS_TOPLEVEL_PROJECT})
-option(THREADSCHEDULE_BUILD_TESTS "Build tests" ON)
+option(THREADSCHEDULE_BUILD_TESTS "Build tests" OFF)
 option(THREADSCHEDULE_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(THREADSCHEDULE_INSTALL "Generate install target" ${THREADSCHEDULE_IS_TOPLEVEL_PROJECT})
 option(THREADSCHEDULE_RUNTIME "Build shared runtime for global registry (non header-only)" OFF)
+option(THREADSCHEDULE_BUILD_DOCS "Build API documentation with Doxygen" ${THREADSCHEDULE_IS_TOPLEVEL_PROJECT})
 
 # CPM support (optional, download if building tests or benchmarks)
 if(THREADSCHEDULE_BUILD_TESTS OR THREADSCHEDULE_BUILD_BENCHMARKS)
@@ -224,6 +225,54 @@ if(THREADSCHEDULE_RUNTIME)
     endif()
     set_target_properties(ThreadScheduleRuntime PROPERTIES OUTPUT_NAME "threadschedule")
     add_library(ThreadSchedule::Runtime ALIAS ThreadScheduleRuntime)
+endif()
+
+# Documentation (Doxygen + Awesome theme)
+if(THREADSCHEDULE_BUILD_DOCS)
+    find_package(Doxygen QUIET)
+    if(DOXYGEN_FOUND)
+        # Prepare theme assets directory in the build tree
+        set(DOXYGEN_THEME_DIR ${CMAKE_BINARY_DIR}/docs/theme)
+        file(MAKE_DIRECTORY ${DOXYGEN_THEME_DIR})
+
+        # Download minimal set of files from doxygen-awesome-css
+        set(DOXYGEN_AWESOME_BASE_URL https://raw.githubusercontent.com/jothepro/doxygen-awesome-css/v2.3.3)
+        file(DOWNLOAD ${DOXYGEN_AWESOME_BASE_URL}/doxygen-awesome.css
+            ${DOXYGEN_THEME_DIR}/doxygen-awesome.css
+            STATUS _dl_status_css)
+        if(NOT _dl_status_css EQUAL 0)
+            message(FATAL_ERROR "Failed to download doxygen-awesome.css: ${_dl_status_css}")
+        endif()
+        file(DOWNLOAD ${DOXYGEN_AWESOME_BASE_URL}/doxygen-awesome-sidebar-only.css
+            ${DOXYGEN_THEME_DIR}/doxygen-awesome-sidebar-only.css
+            STATUS _dl_status_sidebar)
+        if(NOT _dl_status_sidebar EQUAL 0)
+            message(FATAL_ERROR "Failed to download doxygen-awesome-sidebar-only.css: ${_dl_status_sidebar}")
+        endif()
+        file(DOWNLOAD ${DOXYGEN_AWESOME_BASE_URL}/doxygen-awesome-darkmode-toggle.js
+            ${DOXYGEN_THEME_DIR}/doxygen-awesome-darkmode-toggle.js
+            STATUS _dl_status_js)
+        if(NOT _dl_status_js EQUAL 0)
+            message(FATAL_ERROR "Failed to download doxygen-awesome-darkmode-toggle.js: ${_dl_status_js}")
+        endif()
+        # Configure Doxygen file
+        set(DOXYGEN_OUTPUT_DIR ${CMAKE_BINARY_DIR}/docs/doxygen)
+        configure_file(
+            ${CMAKE_SOURCE_DIR}/Doxyfile
+            ${CMAKE_BINARY_DIR}/Doxyfile
+            @ONLY
+        )
+
+        add_custom_target(docs
+            COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/Doxyfile
+            BYPRODUCTS ${DOXYGEN_OUTPUT_DIR}/html/index.html
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMENT "Generating API documentation with Doxygen (Awesome theme)"
+            VERBATIM
+        )
+    else()
+        message(STATUS "Doxygen not found. 'docs' target will not be available.")
+    endif()
 endif()
 
 # Installation

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,64 @@
+PROJECT_NAME           = "ThreadSchedule"
+PROJECT_NUMBER         = @PROJECT_VERSION@
+PROJECT_BRIEF          = "Modern C++ thread management library"
+OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/docs/doxygen
+CREATE_SUBDIRS         = NO
+ALLOW_UNICODE_NAMES    = YES
+OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+OPTIMIZE_OUTPUT_SLICE  = NO
+MARKDOWN_SUPPORT       = YES
+AUTOLINK_SUPPORT       = YES
+USE_MDFILE_AS_MAINPAGE = README.md
+
+FULL_PATH_NAMES        = NO
+STRIP_FROM_PATH        = @CMAKE_SOURCE_DIR@
+
+INPUT                  = README.md include docs
+FILE_PATTERNS          = *.hpp *.md
+RECURSIVE              = YES
+EXCLUDE_PATTERNS       = */build/* */.git/* */install/*
+
+EXTRACT_ALL            = NO
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = NO
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_ANON_NSPACES   = YES
+
+QUIET                  = YES
+WARN_IF_UNDOCUMENTED   = NO
+WARN_AS_ERROR          = NO
+
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+GENERATE_LATEX         = NO
+GENERATE_XML           = YES
+XML_OUTPUT             = xml
+
+# Doxygen Awesome theme integration (downloaded into build dir by CMake)
+HTML_EXTRA_STYLESHEET  = \
+  @CMAKE_BINARY_DIR@/docs/theme/doxygen-awesome.css \
+  @CMAKE_BINARY_DIR@/docs/theme/doxygen-awesome-sidebar-only.css
+HTML_EXTRA_FILES       = \
+  @CMAKE_BINARY_DIR@/docs/theme/doxygen-awesome-darkmode-toggle.js
+
+HTML_COLORSTYLE        = LIGHT
+
+# Source browsing
+SOURCE_BROWSER         = YES
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = YES
+REFERENCES_RELATION    = YES
+VERBATIM_HEADERS       = YES
+
+# Diagrams
+HAVE_DOT               = YES
+DOT_NUM_THREADS        = 0
+CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
+DOT_IMAGE_FORMAT       = svg
+INTERACTIVE_SVG        = YES
+

--- a/docs/README-DOCS.md
+++ b/docs/README-DOCS.md
@@ -1,0 +1,20 @@
+### API Documentation (Doxygen + Awesome Theme)
+
+This project provides a modern Doxygen setup using the Doxygen Awesome theme.
+
+Prerequisites:
+- Doxygen installed (via your package manager)
+
+Build the documentation:
+```bash
+cmake -S . -B build -DTHREADSCHEDULE_BUILD_DOCS=ON
+cmake --build build --target docs
+```
+
+Open the generated HTML:
+- `build/docs/doxygen/html/index.html`
+
+Notes:
+- The Awesome theme assets are automatically downloaded into the build directory during configure.
+- The documentation includes headers under `include/` and uses the repository `README.md` as the landing page.
+


### PR DESCRIPTION
- Disabled test builds by default and added an option to build API documentation using Doxygen.
- Introduced a Doxyfile for documentation configuration and a custom target for generating docs.
- Updated GitHub Actions workflow to build and deploy Doxygen documentation to GitHub Pages.
- Added README-DOCS.md to guide users on building and accessing the generated documentation.