### PR TITLE
Add ABI compatibility integration tests for runtime

### DIFF
--- a/.github/workflows/abi-compat.yml
+++ b/.github/workflows/abi-compat.yml
@@ -1,0 +1,126 @@
+name: ABI Compatibility (runtime)
+
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
+    branches: [ main, dev ]
+  workflow_dispatch:
+    inputs:
+      expected_abi_break:
+        description: "Allow ABI failures"
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  abi-compat:
+    name: ${{ matrix.os }} old-offset:${{ matrix.offset }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+        offset: [ 1, 2, 3 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Fetch tags (ensure up-to-date)
+        run: git fetch --tags --force
+
+      - name: Compute major-change flag
+        id: major_flag
+        shell: bash
+        run: |
+          set -euo pipefail
+          REF="${GITHUB_REF}"
+          # Default
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          # Only for tag refs like refs/tags/vX.Y.Z
+          if [[ "$REF" =~ ^refs/tags/v([0-9]+)\..* ]]; then
+            CUR_MAJ="${BASH_REMATCH[1]}"
+            # Collect tags newest first
+            mapfile -t TAGS < <(git tag --sort=-creatordate)
+            PREV=""
+            for t in "${TAGS[@]}"; do
+              if [[ "$t" != "${REF#refs/tags/}" ]]; then
+                PREV="$t"; break
+              fi
+            done
+            if [[ -n "$PREV" && "$PREV" =~ ^v([0-9]+)\..* ]]; then
+              PREV_MAJ="${BASH_REMATCH[1]}"
+              if [[ "$CUR_MAJ" != "$PREV_MAJ" ]]; then
+                echo "changed=true" >> "$GITHUB_OUTPUT"
+              fi
+            fi
+          fi
+
+      - name: Set up CMake
+        uses: jwlawson/actions-setup-cmake@v2
+
+      - name: Configure (current) with runtime
+        if: runner.os != 'Windows'
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -DTHREADSCHEDULE_RUNTIME=ON -DCMAKE_INSTALL_PREFIX=${RUNNER_TEMP}/ts-install
+      - name: Build (current)
+        if: runner.os != 'Windows'
+        run: cmake --build build --config Release --parallel
+      - name: Install (current)
+        if: runner.os != 'Windows'
+        run: cmake --install build --config Release
+
+      - name: Configure (current) with runtime [Windows]
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cmake -B build -G "Visual Studio 17 2022" -A x64 -DTHREADSCHEDULE_RUNTIME=ON -DCMAKE_INSTALL_PREFIX="$env:RUNNER_TEMP/ts-install"
+      - name: Build (current) [Windows]
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: cmake --build build --config Release --parallel
+      - name: Install (current) [Windows]
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: cmake --install build --config Release
+
+      - name: Configure integration test (runtime_abi_compat)
+        if: runner.os != 'Windows'
+        working-directory: integration_tests/runtime_abi_compat
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -DTHREADSCHEDULE_RUNTIME=ON -DRUNTIME_ABI_OLD_OFFSET=${{ matrix.offset }} -DCMAKE_PREFIX_PATH="${RUNNER_TEMP}/ts-install"
+      - name: Build integration test
+        if: runner.os != 'Windows'
+        working-directory: integration_tests/runtime_abi_compat
+        run: cmake --build build --config Release --parallel
+      - name: Run tests (ctest)
+        if: runner.os != 'Windows'
+        working-directory: integration_tests/runtime_abi_compat
+        env:
+          CTEST_OUTPUT_ON_FAILURE: 1
+        run: ctest --test-dir build -C Release --output-on-failure
+        continue-on-error: ${{ inputs.expected_abi_break == true || steps.major_flag.outputs.changed == 'true' }}
+
+      - name: Configure integration test (runtime_abi_compat) [Windows]
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: integration_tests/runtime_abi_compat
+        run: |
+          cmake -B build -G "Visual Studio 17 2022" -A x64 -DTHREADSCHEDULE_RUNTIME=ON -DRUNTIME_ABI_OLD_OFFSET=${{ matrix.offset }} -DCMAKE_PREFIX_PATH="$env:RUNNER_TEMP/ts-install"
+      - name: Build integration test [Windows]
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: integration_tests/runtime_abi_compat
+        run: cmake --build build --config Release --parallel
+      - name: Run tests (ctest) [Windows]
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: integration_tests/runtime_abi_compat
+        run: ctest --test-dir build -C Release --output-on-failure
+        continue-on-error: ${{ inputs.expected_abi_break == true || steps.major_flag.outputs.changed == 'true' }}
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
 - Added: Windows thread affinity retrieval via `GetThreadGroupAffinity` in `include/threadschedule/thread_wrapper.hpp`
+- Added: Integration test `integration_tests/runtime_abi_compat` to validate ABI compatibility (shared runtime) between current library and older tags
+- Added: Parameterization for ABI test old version selection via `RUNTIME_ABI_OLD_REF` or `RUNTIME_ABI_OLD_OFFSET`
+- Added: GitHub Actions workflow `abi-compat.yml` to run ABI tests on Linux and Windows for the last 3 tags; allowed failure only on major version bumps (or when explicitly enabled)
+- Docs: Updated `integration_tests/README.md` with usage for ABI compatibility scenario
 
 ## v1.1.0
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -93,6 +93,36 @@ registry().for_each([](RegisteredThreadInfo const& info){ /* sees all threads */
 set_external_registry(nullptr); // reset to local
 ```
 
+---
+
+### 4. runtime_abi_compat/
+
+**Pattern:** ABI compatibility check in shared runtime mode across versions
+
+**Setup:**
+- `libA` builds against the current ThreadSchedule (this workspace)
+- `libB` builds against the last git tag of ThreadSchedule (fetched via ExternalProject)
+- Main app links both, and at runtime only the current `ThreadSchedule::Runtime` is provided next to the executable
+
+**What it tests:**
+- Mixed-version DSOs interoperate through a single shared runtime without ABI breaks
+- Old consumer (`libB`) can register and enumerate threads via the new runtime
+
+**Build requirement:** `THREADSCHEDULE_RUNTIME=ON`
+
+**Run:**
+```bash
+cd integration_tests/runtime_abi_compat
+# Option A: pick a specific tag/ref
+cmake -B build -DTHREADSCHEDULE_RUNTIME=ON -DRUNTIME_ABI_OLD_REF=v1.0.0
+
+# Option B: pick N-th latest tag (1=latest, 2=previous, ...)
+cmake -B build -DTHREADSCHEDULE_RUNTIME=ON -DRUNTIME_ABI_OLD_OFFSET=2
+
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
 ## How It Works
 
 These are **true integration tests**, not unit tests:

--- a/integration_tests/runtime_abi_compat/CMakeLists.txt
+++ b/integration_tests/runtime_abi_compat/CMakeLists.txt
@@ -1,0 +1,87 @@
+cmake_minimum_required(VERSION 3.14)
+project(RuntimeAbiCompatibility LANGUAGES CXX)
+
+if(NOT THREADSCHEDULE_RUNTIME)
+  message(STATUS "Skipping runtime_abi_compat integration because THREADSCHEDULE_RUNTIME is OFF")
+  return()
+endif()
+
+include(CTest)
+enable_testing()
+
+include(ExternalProject)
+
+# Parameters to select the old version to test against
+set(RUNTIME_ABI_OLD_REF "" CACHE STRING "Git ref/tag/commit for old ThreadSchedule to test against")
+set(RUNTIME_ABI_OLD_OFFSET "" CACHE STRING "N-th latest tag to use if OLD_REF not set (1=latest, 2=previous, ...)")
+
+# Determine repository URL for cloning the old ref
+execute_process(
+  COMMAND git config --get remote.origin.url
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE TS_REPO_URL
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+set(TS_OLD_REF "")
+
+if(NOT RUNTIME_ABI_OLD_REF STREQUAL "")
+  set(TS_OLD_REF ${RUNTIME_ABI_OLD_REF})
+else()
+  if(NOT RUNTIME_ABI_OLD_OFFSET STREQUAL "")
+    # Collect tags sorted by creation date (newest first) and pick by offset
+    execute_process(
+      COMMAND git tag --sort=-creatordate
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE _TS_TAGS_RAW
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(REPLACE "\n" ";" _TS_TAGS_LIST "${_TS_TAGS_RAW}")
+    if(_TS_TAGS_LIST)
+      math(EXPR _TS_IDX "${RUNTIME_ABI_OLD_OFFSET} - 1" OUTPUT_FORMAT DECIMAL)
+      list(LENGTH _TS_TAGS_LIST _TS_TAGS_LEN)
+      if(_TS_IDX GREATER_EQUAL 0 AND _TS_IDX LESS _TS_TAGS_LEN)
+        list(GET _TS_TAGS_LIST ${_TS_IDX} TS_OLD_REF)
+      endif()
+    endif()
+  endif()
+  if(TS_OLD_REF STREQUAL "")
+    # Fallback: use the latest tag
+    execute_process(
+      COMMAND git describe --tags --abbrev=0
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE TS_OLD_REF
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  endif()
+endif()
+
+if(TS_OLD_REF STREQUAL "")
+  message(FATAL_ERROR "Could not determine old ref for ABI compat test (set RUNTIME_ABI_OLD_REF or RUNTIME_ABI_OLD_OFFSET)")
+endif()
+
+if(TS_REPO_URL STREQUAL "")
+  set(TS_REPO_URL https://github.com/Katze719/ThreadSchedule.git)
+endif()
+
+set(OLD_TS_PREFIX ${CMAKE_BINARY_DIR}/old_ts_install)
+
+ExternalProject_Add(ThreadScheduleOld
+  GIT_REPOSITORY ${TS_REPO_URL}
+  GIT_TAG ${TS_OLD_REF}
+  UPDATE_DISCONNECTED 1
+  SOURCE_SUBDIR .
+  CMAKE_ARGS
+    -DTHREADSCHEDULE_RUNTIME=ON
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    -DCMAKE_BUILD_TYPE=$<IF:$<CONFIG:>,${CMAKE_BUILD_TYPE},$<CONFIG>>
+    -DCMAKE_INSTALL_PREFIX=${OLD_TS_PREFIX}
+  BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<IF:$<CONFIG:>,${CMAKE_BUILD_TYPE},$<CONFIG>>
+  INSTALL_COMMAND ${CMAKE_COMMAND} --install <BINARY_DIR> --config $<IF:$<CONFIG:>,${CMAKE_BUILD_TYPE},$<CONFIG>>
+)
+
+add_subdirectory(libA)
+add_subdirectory(libB)
+add_subdirectory(main_app)
+
+

--- a/integration_tests/runtime_abi_compat/libA/CMakeLists.txt
+++ b/integration_tests/runtime_abi_compat/libA/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.14)
+project(RuntimeAbiCompatLibA VERSION 1.0.0 LANGUAGES CXX)
+
+find_package(ThreadSchedule REQUIRED)
+
+add_library(runtime_abi_libA SHARED
+    src/library_ra.cpp
+)
+
+target_include_directories(runtime_abi_libA
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(runtime_abi_libA
+    PUBLIC
+        ThreadSchedule::ThreadSchedule
+        ThreadSchedule::Runtime
+)
+
+target_compile_features(runtime_abi_libA PUBLIC cxx_std_17)
+
+if(WIN32)
+    target_compile_definitions(runtime_abi_libA PRIVATE BUILD_RUNTIME_LIBA_SHARED)
+endif()
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+install(TARGETS runtime_abi_libA
+    EXPORT RuntimeAbiLibATargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(EXPORT RuntimeAbiLibATargets
+    FILE RuntimeAbiLibATargets.cmake
+    NAMESPACE RuntimeAbi::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/RuntimeAbiLibA
+)
+
+

--- a/integration_tests/runtime_abi_compat/libA/include/library_ra/library_ra.hpp
+++ b/integration_tests/runtime_abi_compat/libA/include/library_ra/library_ra.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#if defined(_WIN32) && defined(BUILD_RUNTIME_LIBA_SHARED)
+#define RUNTIME_LIBA_API __declspec(dllexport)
+#else
+#define RUNTIME_LIBA_API
+#endif
+
+namespace runtime_libA
+{
+RUNTIME_LIBA_API void start_worker(char const* name);
+RUNTIME_LIBA_API void wait_for_threads();
+} // namespace runtime_libA

--- a/integration_tests/runtime_abi_compat/libA/src/library_ra.cpp
+++ b/integration_tests/runtime_abi_compat/libA/src/library_ra.cpp
@@ -1,0 +1,38 @@
+#include <chrono>
+#include <library_ra/library_ra.hpp>
+#include <memory>
+#include <mutex>
+#include <threadschedule/registered_threads.hpp>
+#include <threadschedule/thread_registry.hpp>
+#include <threadschedule/thread_wrapper.hpp>
+#include <vector>
+
+using namespace threadschedule;
+
+namespace runtime_libA
+{
+
+static std::mutex threads_mutex;
+static std::vector<std::unique_ptr<ThreadWrapper>> threads;
+
+void start_worker(char const* name)
+{
+    std::lock_guard<std::mutex> lock(threads_mutex);
+    threads.push_back(std::make_unique<ThreadWrapper>([n = std::string(name)]() {
+        AutoRegisterCurrentThread guard(n, "RuntimeAbiLibA");
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }));
+}
+
+void wait_for_threads()
+{
+    std::lock_guard<std::mutex> lock(threads_mutex);
+    for (auto& t : threads)
+    {
+        if (t->joinable())
+            t->join();
+    }
+    threads.clear();
+}
+
+} // namespace runtime_libA

--- a/integration_tests/runtime_abi_compat/libB/CMakeLists.txt
+++ b/integration_tests/runtime_abi_compat/libB/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.14)
+project(RuntimeAbiCompatLibB VERSION 1.0.0 LANGUAGES CXX)
+
+find_package(Threads REQUIRED)
+
+# Consume the previously installed ThreadSchedule (previous tag)
+set(THREADSCHEDULE_OLD_CONFIG_DIR ${OLD_TS_PREFIX}/lib64/cmake/ThreadSchedule)
+if(WIN32)
+  set(THREADSCHEDULE_OLD_CONFIG_DIR ${OLD_TS_PREFIX}/lib/cmake/ThreadSchedule)
+endif()
+
+find_package(ThreadSchedule REQUIRED PATHS ${THREADSCHEDULE_OLD_CONFIG_DIR} NO_DEFAULT_PATH)
+
+add_library(runtime_abi_libB SHARED
+    src/library_rb.cpp
+)
+
+target_include_directories(runtime_abi_libB
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(runtime_abi_libB
+    PUBLIC
+        ThreadSchedule::ThreadSchedule
+        ThreadSchedule::Runtime
+)
+
+target_compile_features(runtime_abi_libB PUBLIC cxx_std_17)
+
+if(WIN32)
+    target_compile_definitions(runtime_abi_libB PRIVATE BUILD_RUNTIME_LIBB_SHARED)
+endif()
+
+add_dependencies(runtime_abi_libB ThreadScheduleOld)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+install(TARGETS runtime_abi_libB
+    EXPORT RuntimeAbiLibBTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(EXPORT RuntimeAbiLibBTargets
+    FILE RuntimeAbiLibBTargets.cmake
+    NAMESPACE RuntimeAbi::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/RuntimeAbiLibB
+)
+
+

--- a/integration_tests/runtime_abi_compat/libB/include/library_rb/library_rb.hpp
+++ b/integration_tests/runtime_abi_compat/libB/include/library_rb/library_rb.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#if defined(_WIN32) && defined(BUILD_RUNTIME_LIBB_SHARED)
+#define RUNTIME_LIBB_API __declspec(dllexport)
+#else
+#define RUNTIME_LIBB_API
+#endif
+
+namespace runtime_libB
+{
+RUNTIME_LIBB_API void start_worker(char const* name);
+RUNTIME_LIBB_API void wait_for_threads();
+} // namespace runtime_libB

--- a/integration_tests/runtime_abi_compat/libB/src/library_rb.cpp
+++ b/integration_tests/runtime_abi_compat/libB/src/library_rb.cpp
@@ -1,0 +1,38 @@
+#include <chrono>
+#include <library_rb/library_rb.hpp>
+#include <memory>
+#include <mutex>
+#include <threadschedule/registered_threads.hpp>
+#include <threadschedule/thread_registry.hpp>
+#include <threadschedule/thread_wrapper.hpp>
+#include <vector>
+
+using namespace threadschedule;
+
+namespace runtime_libB
+{
+
+static std::mutex threads_mutex;
+static std::vector<std::unique_ptr<ThreadWrapper>> threads;
+
+void start_worker(char const* name)
+{
+    std::lock_guard<std::mutex> lock(threads_mutex);
+    threads.push_back(std::make_unique<ThreadWrapper>([n = std::string(name)]() {
+        AutoRegisterCurrentThread guard(n, "RuntimeAbiLibB-OLD");
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }));
+}
+
+void wait_for_threads()
+{
+    std::lock_guard<std::mutex> lock(threads_mutex);
+    for (auto& t : threads)
+    {
+        if (t->joinable())
+            t->join();
+    }
+    threads.clear();
+}
+
+} // namespace runtime_libB

--- a/integration_tests/runtime_abi_compat/main_app/CMakeLists.txt
+++ b/integration_tests/runtime_abi_compat/main_app/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.14)
+project(RuntimeAbiCompatMain LANGUAGES CXX)
+
+find_package(ThreadSchedule REQUIRED)
+
+add_executable(runtime_abi_main main.cpp)
+target_link_libraries(runtime_abi_main PRIVATE
+    ThreadSchedule::ThreadSchedule
+    ThreadSchedule::Runtime
+    runtime_abi_libA
+    runtime_abi_libB
+)
+target_compile_features(runtime_abi_main PRIVATE cxx_std_17)
+
+add_custom_command(TARGET runtime_abi_main POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        $<TARGET_FILE:ThreadSchedule::ThreadScheduleRuntime>
+        $<TARGET_FILE_DIR:runtime_abi_main>
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        $<TARGET_FILE:runtime_abi_libA>
+        $<TARGET_FILE_DIR:runtime_abi_main>
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        $<TARGET_FILE:runtime_abi_libB>
+        $<TARGET_FILE_DIR:runtime_abi_main>
+)
+
+if(UNIX AND NOT APPLE)
+    # Ensure loader finds the runtime next to the executable
+    set_target_properties(runtime_abi_main PROPERTIES BUILD_RPATH "$ORIGIN")
+endif()
+
+enable_testing()
+add_test(NAME RuntimeAbiCompatibilityTest COMMAND runtime_abi_main)
+
+if(UNIX AND NOT APPLE)
+    set_tests_properties(RuntimeAbiCompatibilityTest PROPERTIES
+        ENVIRONMENT "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:runtime_abi_main>")
+endif()
+
+

--- a/integration_tests/runtime_abi_compat/main_app/main.cpp
+++ b/integration_tests/runtime_abi_compat/main_app/main.cpp
@@ -1,0 +1,101 @@
+#include <chrono>
+#include <iostream>
+#include <library_ra/library_ra.hpp>
+#include <library_rb/library_rb.hpp>
+#include <string>
+#include <thread>
+#include <threadschedule/thread_registry.hpp>
+#include <vector>
+
+using namespace threadschedule;
+
+int main()
+{
+    std::cout << "\n=== Runtime ABI Compatibility Test ===\n";
+    bool success = true;
+
+    // Phase 1: Start 4 threads from two DSOs (A=new, B=old)
+    std::cout << "\nPhase 1: Starting 4 threads (LibA=new, LibB=old) ...\n";
+    runtime_libA::start_worker("ra-1");
+    runtime_libA::start_worker("ra-2");
+    runtime_libB::start_worker("rb-1");
+    runtime_libB::start_worker("rb-2");
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    // Phase 2: Verify shared registry sees all 4 threads
+    std::cout << "\nPhase 2: Verifying shared runtime registry...\n";
+    size_t total = registry().count();
+    size_t a = registry()
+                   .filter([](auto const& e) { return e.componentTag.find("RuntimeAbiLibA") != std::string::npos; })
+                   .count();
+    size_t b = registry()
+                   .filter([](auto const& e) { return e.componentTag.find("RuntimeAbiLibB-OLD") != std::string::npos; })
+                   .count();
+
+    std::cout << "  Total threads in runtime registry: " << total << "\n";
+    std::cout << "  LibA(new): " << a << ", LibB(old): " << b << "\n";
+
+    if (total != 4)
+    {
+        std::cerr << "  ERROR: Expected 4 total threads, got " << total << "\n";
+        success = false;
+    }
+    if (a != 2)
+    {
+        std::cerr << "  ERROR: Expected 2 threads from LibA(new), got " << a << "\n";
+        success = false;
+    }
+    if (b != 2)
+    {
+        std::cerr << "  ERROR: Expected 2 threads from LibB(old), got " << b << "\n";
+        success = false;
+    }
+
+    // Phase 3: Basic predicates across mixed versions
+    std::cout << "\nPhase 3: Testing query predicates...\n";
+    bool has_libA =
+        registry().any([](auto const& e) { return e.componentTag.find("RuntimeAbiLibA") != std::string::npos; });
+    bool has_libB =
+        registry().any([](auto const& e) { return e.componentTag.find("RuntimeAbiLibB-OLD") != std::string::npos; });
+    bool all_alive = registry().all([](auto const& e) { return e.alive; });
+
+    std::cout << "  Has LibA(new): " << (has_libA ? "yes" : "no") << "\n";
+    std::cout << "  Has LibB(old): " << (has_libB ? "yes" : "no") << "\n";
+    std::cout << "  All alive: " << (all_alive ? "yes" : "no") << "\n";
+
+    if (!has_libA || !has_libB || !all_alive)
+    {
+        std::cerr << "  ERROR: Predicate checks failed (possible ABI/runtime mismatch)\n";
+        success = false;
+    }
+
+    // Phase 4: Wait for all threads and verify registry is empty
+    std::cout << "\nPhase 4: Waiting for all threads to finish...\n";
+    runtime_libA::wait_for_threads();
+    runtime_libB::wait_for_threads();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    size_t final_count = registry().count();
+    bool is_empty = registry().empty();
+
+    std::cout << "  Final count: " << final_count << ", Empty: " << (is_empty ? "yes" : "no") << "\n";
+
+    if (final_count != 0 || !is_empty)
+    {
+        std::cerr << "  ERROR: Registry should be empty at end\n";
+        success = false;
+    }
+
+    if (success)
+    {
+        std::cout << "\n=== Runtime ABI compatibility test PASSED ===\n";
+        return 0;
+    }
+    else
+    {
+        std::cerr << "\n=== Runtime ABI compatibility test FAILED ===\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow for ABI compatibility checks across different runtime versions.
- Added integration tests to verify that mixed-version dynamic shared objects (DSOs) can interoperate without ABI breaks.
- Created `runtime_abi_compat` directory with necessary CMake configurations and test implementations for two libraries (`libA` and `libB`).
- Updated `README.md` to document the new integration test setup and usage instructions.
- Ensured that the tests validate thread registration and interaction between the new and old versions of the runtime.