### PR TITLE
Add optional nrvo warning flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Build: Conditionally enable `-Wnrvo` via compiler feature detection
+- Fix: Ensure NRVO in `affinity_for_node` by returning a single named local
+  `ThreadAffinity` on all paths (removes `-Wnrvo` warning).
+
 ## v1.2.1
 
 - fix build for some older mingw version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,11 +160,39 @@ if(UNIX AND NOT APPLE AND NOT WIN32)
 endif()
 # Windows (MSVC and MinGW) use Threads::Threads which is already linked above
 
+# Check support for optional warning flags (e.g. -Wnrvo)
+include(CheckCXXCompilerFlag)
+
+function(ts_add_warning_if_supported flag out_var)
+    string(REPLACE "-" "_" _flag_var "${flag}")
+    check_cxx_compiler_flag("${flag}" ${_flag_var})
+    if(${_flag_var})
+        if(DEFINED ${out_var} AND NOT "${${out_var}}" STREQUAL "")
+            set(${out_var} "${${out_var}};${flag}" PARENT_SCOPE)
+        else()
+            set(${out_var} "${flag}" PARENT_SCOPE)
+        endif()
+    endif()
+endfunction()
+
+# Collect optional warnings conditionally
+set(TS_OPTIONAL_WARNINGS "")
+ts_add_warning_if_supported("-Wnrvo" TS_OPTIONAL_WARNINGS)
+
+# Wrap optional warnings in BUILD_INTERFACE generator expressions, one per flag
+set(TS_OPTIONAL_WARNINGS_GE "")
+foreach(_w ${TS_OPTIONAL_WARNINGS})
+    list(APPEND TS_OPTIONAL_WARNINGS_GE $<BUILD_INTERFACE:${_w}>)
+endforeach()
+
 # Compiler-specific warnings and flags (only for top-level project to avoid polluting parent)
 if(THREADSCHEDULE_IS_TOPLEVEL_PROJECT)
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         target_compile_options(ThreadSchedule INTERFACE
-            $<BUILD_INTERFACE:-Wall -Wextra -Wpedantic>
+            $<BUILD_INTERFACE:-Wall>
+            $<BUILD_INTERFACE:-Wextra>
+            $<BUILD_INTERFACE:-Wpedantic>
+            ${TS_OPTIONAL_WARNINGS_GE}
         )
         # MinGW (GCC): allow permissive mode for broader compatibility when requested
         if(MINGW AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/include/threadschedule/topology.hpp
+++ b/include/threadschedule/topology.hpp
@@ -137,11 +137,11 @@ inline auto read_topology() -> CpuTopology
 inline auto affinity_for_node(int node_index, int thread_index, int threads_per_node = 1) -> ThreadAffinity
 {
     CpuTopology topo = read_topology();
+    ThreadAffinity aff;
     if (topo.numa_nodes <= 0)
-        return {};
+        return aff;
     int const n = (node_index % topo.numa_nodes + topo.numa_nodes) % topo.numa_nodes;
     auto const& cpus = topo.node_to_cpus[n];
-    ThreadAffinity aff;
     if (cpus.empty())
         return aff;
 


### PR DESCRIPTION
- Introduced a function to check and add optional compiler warning flags if supported.
- Updated the CMakeLists.txt to conditionally collect and wrap these warnings for the ThreadSchedule target.
- Modified the affinity_for_node function in topology.hpp to ensure a default ThreadAffinity object is returned when no NUMA nodes are present, improving code clarity.